### PR TITLE
Move dependency from devDependencies to production dependencies

### DIFF
--- a/stylelint-config-dcos/package.json
+++ b/stylelint-config-dcos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-dcos",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "DC/OS Stylelint Rules",
   "author": {
     "name": "Mesosphere Frontend Team",
@@ -16,7 +16,7 @@
   "files": [
     "index.js"
   ],
-  "devDependencies": {
+  "dependencies": {
     "stylelint-config-standard": "13.0.0"
   }
 }


### PR DESCRIPTION
This package relies on `stylelint-config-standard`, not just as a `devDependency`
