### PR TITLE
Update based on deprecated styleline rules

### DIFF
--- a/stylelint-config-dcos/index.js
+++ b/stylelint-config-dcos/index.js
@@ -1,5 +1,9 @@
 module.exports = {
   "extends": "stylelint-config-standard",
+  "plugins": [
+    "stylelint-order",
+    "stylelint-no-browser-hacks/lib"
+  ],
   "rules": {
     "at-rule-empty-line-before": ["always", {
       except: ["blockless-after-same-name-blockless"],
@@ -9,10 +13,8 @@ module.exports = {
     "at-rule-no-unknown": true,
     "at-rule-no-vendor-prefix": true,
     "block-closing-brace-newline-before": "always",
-    "block-no-single-line": true,
     "block-opening-brace-newline-after": "always",
     "color-named": "never",
-    "declaration-block-properties-order": "alphabetical",
     "declaration-block-semicolon-newline-after": "always",
     "declaration-block-semicolon-newline-before": "never-multi-line",
     "declaration-colon-space-after": "always-single-line",
@@ -26,26 +28,28 @@ module.exports = {
     "function-url-quotes": "always",
     "media-feature-name-no-vendor-prefix": true,
     "media-query-list-comma-space-after": "always",
-    "no-browser-hacks": true,
     "no-duplicate-selectors": true,
+    "order/order": [
+      "custom-properties",
+      "declarations"
+    ],
+    "order/properties-alphabetical-order": true,
+    "plugin/no-browser-hacks": [true, {
+        browsers: [
+            "last 2 versions",
+            "ie >=7"
+        ]
+    }],
     "property-no-vendor-prefix": true,
-    "rule-nested-empty-line-before": [
-        "always",
-        {
-          "ignore": ["after-comment"]
-        }
-      ],
-    "rule-non-nested-empty-line-before": [
-        "always",
-        {
-          "ignore": ["after-comment"]
-        }
-      ],
+    "rule-empty-line-before": [
+      "always", {
+        except: [],
+        ignore: ["after-comment"],
+    } ],
     "selector-attribute-quotes": "always",
     "selector-list-comma-newline-before": "never-multi-line",
     "selector-pseudo-element-colon-notation": "single",
     "string-quotes": "single",
-    "stylelint-disable-reason": "always-before",
     "value-keyword-case": [
         "lower",
         {

--- a/stylelint-config-dcos/package.json
+++ b/stylelint-config-dcos/package.json
@@ -17,6 +17,11 @@
     "index.js"
   ],
   "dependencies": {
-    "stylelint-config-standard": "13.0.0"
+    "stylelint-config-standard": "17.0.0"
+  },
+  "devDependencies": {
+    "stylelint": "8.1.1",
+    "stylelint-no-browser-hacks": "1.1.0",
+    "stylelint-order": "0.7.0"
   }
 }


### PR DESCRIPTION
With the latest version of stylelint, several rules were deprecated. Update the rule set to use the suggested alternatives. Following this merge, we need to update the package in npm and then dcos-ui accordingly.